### PR TITLE
Overlay preview area onto page editor

### DIFF
--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -147,9 +147,28 @@
             font-family: "Minecraft Seven", monospace;
             font-size: 20px;          /* new – larger glyphs */
         }
-        #editor-preview {
+        .editor-container {
+            position: relative;
             width: 114px;
             height: 280px;              /* 14 lines at 20px each */
+        }
+        #editor-page {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 1px solid #555;
+            padding: 4px;
+            background: transparent;
+            color: transparent;         /* hide text but keep caret */
+            caret-color: #ffffff;
+            resize: none;
+            overflow: hidden;
+        }
+        #editor-preview {
+            pointer-events: none;
+            position: absolute;
+            inset: 0;
             border: 1px solid #555;
             padding: 4px;
             background: #2b2b2b;
@@ -243,8 +262,10 @@
             </div>
 
             <!-- page editor -->
-            <textarea id="editor-page" rows="10"></textarea>
-            <pre id="editor-preview" class="book-display"></pre>
+            <div class="editor-container">
+                <textarea id="editor-page" rows="14"></textarea>
+                <pre id="editor-preview" class="book-display"></pre>
+            </div>
 
             <!-- Minecraft formatting toolbar -->
             <div id="format-toolbar" class="format-toolbar">


### PR DESCRIPTION
## Summary
- overlay preview on top of the textarea to create a single editor view
- add CSS for `.editor-container` and adjust `#editor-page`/`#editor-preview`

## Testing
- `./gradlew test` *(fails: Java home invalid)*

------
https://chatgpt.com/codex/tasks/task_e_688363422cfc832eaf282b9212c1f9d5